### PR TITLE
Add Antares unmount grace period in Orion cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8376,9 +8376,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -212,7 +212,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1452,7 +1452,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2295,7 +2295,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2686,7 +2686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3653,7 +3653,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3673,7 +3673,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5073,7 +5073,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6529,7 +6529,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6567,7 +6567,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7469,7 +7469,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7537,7 +7537,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7655,8 +7655,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scorpiofs"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa605833112079da3f5075eafffd75d9cb02a48ddd8feae7f6c1b83fc7959e43"
+source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=900309f0abc397ccf8b9565ae0da2e3ef1e65618#900309f0abc397ccf8b9565ae0da2e3ef1e65618"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -8431,7 +8430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8778,7 +8777,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9081,7 +9080,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9090,7 +9089,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10452,7 +10451,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,8 +4404,7 @@ dependencies = [
 [[package]]
 name = "libfuse-fs"
 version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61be2a0235d6a5ba30064c172f12d5465da0f013281a0e6675604d0781496e9"
+source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=beecf7dd2906806c686d0c17d80348dddc4a55e9#beecf7dd2906806c686d0c17d80348dddc4a55e9"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -7655,7 +7654,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scorpiofs"
 version = "0.2.2"
-source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=900309f0abc397ccf8b9565ae0da2e3ef1e65618#900309f0abc397ccf8b9565ae0da2e3ef1e65618"
+source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=beecf7dd2906806c686d0c17d80348dddc4a55e9#beecf7dd2906806c686d0c17d80348dddc4a55e9"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4404,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "libfuse-fs"
 version = "0.1.13"
-source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=beecf7dd2906806c686d0c17d80348dddc4a55e9#beecf7dd2906806c686d0c17d80348dddc4a55e9"
+source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=e228b34116f9bc460637894cf5f71ed829e1dc03#e228b34116f9bc460637894cf5f71ed829e1dc03"
 dependencies = [
  "async-trait",
  "bitflags 2.13.0",
@@ -7654,7 +7654,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "scorpiofs"
 version = "0.2.2"
-source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=beecf7dd2906806c686d0c17d80348dddc4a55e9#beecf7dd2906806c686d0c17d80348dddc4a55e9"
+source = "git+https://github.com/web3infra-foundation/scorpiofs.git?rev=e228b34116f9bc460637894cf5f71ed829e1dc03#e228b34116f9bc460637894cf5f71ed829e1dc03"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -39,4 +39,4 @@ serial_test = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-scorpiofs = { git = "https://github.com/web3infra-foundation/scorpiofs.git", rev = "900309f0abc397ccf8b9565ae0da2e3ef1e65618" }
+scorpiofs = { git = "https://github.com/web3infra-foundation/scorpiofs.git", rev = "beecf7dd2906806c686d0c17d80348dddc4a55e9" }

--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -39,4 +39,4 @@ serial_test = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-scorpiofs = "0.2.2"
+scorpiofs = { git = "https://github.com/web3infra-foundation/scorpiofs.git", rev = "900309f0abc397ccf8b9565ae0da2e3ef1e65618" }

--- a/orion/Cargo.toml
+++ b/orion/Cargo.toml
@@ -39,4 +39,4 @@ serial_test = { workspace = true }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-scorpiofs = { git = "https://github.com/web3infra-foundation/scorpiofs.git", rev = "beecf7dd2906806c686d0c17d80348dddc4a55e9" }
+scorpiofs = { git = "https://github.com/web3infra-foundation/scorpiofs.git", rev = "e228b34116f9bc460637894cf5f71ed829e1dc03" }

--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -1549,7 +1549,10 @@ mod tests {
     #[serial]
     fn test_antares_unmount_grace_duration_clamps_and_falls_back() {
         set_antares_unmount_grace_env(Some("50000"));
-        assert_eq!(antares_unmount_grace_duration(), Duration::from_millis(3000));
+        assert_eq!(
+            antares_unmount_grace_duration(),
+            Duration::from_millis(3000)
+        );
 
         set_antares_unmount_grace_env(Some("not-a-number"));
         assert_eq!(antares_unmount_grace_duration(), Duration::from_millis(150));

--- a/orion/src/buck_controller.rs
+++ b/orion/src/buck_controller.rs
@@ -67,12 +67,43 @@ fn retain_antares_mounts() -> bool {
     }
 }
 
+fn antares_unmount_grace_duration() -> Duration {
+    const DEFAULT_MS: u64 = 150;
+    match std::env::var("ORION_ANTARES_UNMOUNT_GRACE_MS") {
+        Ok(raw) => match raw.trim().parse::<u64>() {
+            Ok(ms) => Duration::from_millis(ms.clamp(0, 3_000)),
+            Err(_) => {
+                tracing::warn!(
+                    value = %raw,
+                    default_ms = DEFAULT_MS,
+                    "invalid ORION_ANTARES_UNMOUNT_GRACE_MS, using default"
+                );
+                Duration::from_millis(DEFAULT_MS)
+            }
+        },
+        Err(_) => Duration::from_millis(DEFAULT_MS),
+    }
+}
+
 async fn cleanup_antares_mount(
     task_id: &str,
     mount_id: &str,
     mount_point: Option<&str>,
     reason: &str,
 ) {
+    let grace = antares_unmount_grace_duration();
+    if !grace.is_zero() {
+        tracing::info!(
+            "[Task {}] Waiting {:?} before Antares mount cleanup (mount_id={}, mountpoint={}, reason={})",
+            task_id,
+            grace,
+            mount_id,
+            mount_point.unwrap_or("<unknown>"),
+            reason,
+        );
+        tokio::time::sleep(grace).await;
+    }
+
     match unmount_antares_fs(mount_id).await {
         Ok(true) => tracing::info!(
             "[Task {}] Cleaned Antares mount (mount_id={}, mountpoint={}, reason={})",
@@ -1369,6 +1400,7 @@ mod tests {
     use std::{
         fs,
         path::{Path, PathBuf},
+        time::Duration,
     };
 
     use api_model::buck2::{status::Status, types::ProjectRelativePath};
@@ -1378,8 +1410,9 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::{
-        finish_without_build_if_no_targets, get_build_targets, get_repo_targets,
-        remap_repo_local_change_paths, retain_antares_mounts, validate_project_root_exists,
+        antares_unmount_grace_duration, finish_without_build_if_no_targets, get_build_targets,
+        get_repo_targets, remap_repo_local_change_paths, retain_antares_mounts,
+        validate_project_root_exists,
     };
 
     struct JsonlCleanupGuard {
@@ -1459,6 +1492,16 @@ mod tests {
         }
     }
 
+    fn set_antares_unmount_grace_env(value: Option<&str>) {
+        // SAFETY: these tests are marked serial and only mutate process env inside the test.
+        unsafe {
+            match value {
+                Some(value) => std::env::set_var("ORION_ANTARES_UNMOUNT_GRACE_MS", value),
+                None => std::env::remove_var("ORION_ANTARES_UNMOUNT_GRACE_MS"),
+            }
+        }
+    }
+
     #[test]
     #[serial]
     fn test_retain_antares_mounts_defaults_to_false() {
@@ -1485,6 +1528,33 @@ mod tests {
             );
         }
         set_mount_retention_env(None);
+    }
+
+    #[test]
+    #[serial]
+    fn test_antares_unmount_grace_duration_defaults_to_150ms() {
+        set_antares_unmount_grace_env(None);
+        assert_eq!(antares_unmount_grace_duration(), Duration::from_millis(150));
+    }
+
+    #[test]
+    #[serial]
+    fn test_antares_unmount_grace_duration_accepts_explicit_value() {
+        set_antares_unmount_grace_env(Some("275"));
+        assert_eq!(antares_unmount_grace_duration(), Duration::from_millis(275));
+        set_antares_unmount_grace_env(None);
+    }
+
+    #[test]
+    #[serial]
+    fn test_antares_unmount_grace_duration_clamps_and_falls_back() {
+        set_antares_unmount_grace_env(Some("50000"));
+        assert_eq!(antares_unmount_grace_duration(), Duration::from_millis(3000));
+
+        set_antares_unmount_grace_env(Some("not-a-number"));
+        assert_eq!(antares_unmount_grace_duration(), Duration::from_millis(150));
+
+        set_antares_unmount_grace_env(None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add a configurable grace period before Orion cleans up Antares mounts
- default the drain window to 150ms with bounds checking
- add unit coverage for default, explicit, and fallback grace-period parsing

## Verification
- `cargo test -p orion antares_unmount_grace_duration`
- manual Antares unmount race regression with concurrent write/stat/chmod/remove after drain window